### PR TITLE
Make issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: 🐛 バグ報告
+description: バグを報告する
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。以下の情報を記入してください。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの説明
+      description: バグの内容を詳しく説明してください
+      placeholder: できるだけ具体的に記述してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 再現手順
+      description: バグを再現するための手順を記述してください
+      placeholder: |
+        1. '...' に移動
+        2. '....' をクリック
+        3. '....' までスクロール
+        4. エラーが発生
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      description: 本来期待される動作を記述してください
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: 発生したブラウザ
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - その他

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 質問・相談
+    url: https://github.com/denkathon/event_reserve/discussions
+    about: バグ報告や機能リクエスト以外の質問・相談はDiscussionsをご利用ください。
+
+# Issue作成時のテンプレート設定
+defaults:
+  - template: "bug_report.yml"
+    name: "🐛 バグ報告"
+    about: "バグを報告する"
+  - template: "feature_request.yml"
+    name: "💡 機能リクエスト"
+    about: "新機能のアイデアを提案する"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: 💡 機能リクエスト
+description: 新機能のアイデアを提案する
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        機能の提案ありがとうございます。以下の情報を記入してください。
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 目的
+      description: この機能が解決する問題や目的を説明してください
+      placeholder: 例）〜するため。
+    validations:
+      required: true
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: 要件
+      description: どのようにしたいか機能の要件を説明してください
+      placeholder: 例）〜すること。
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 提案する解決策
+      description: 考えられる解決策を説明してください
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 検討した他の解決策があれば記述してください
+    validations:
+      required: false
+
+  - type: textarea
+    id: images
+    attributes:
+      label: イメージ画像
+      description: スクリーンショットや参考資料などがあれば追加してください
+    validations:
+      required: false


### PR DESCRIPTION
## 目的
- issueの質を安定させ、開発を効率化するため

## 要件
- issueを記入をする際に、テンプレートが設けられる

## 変更点
- `.github`フォルダを作成し、その中にissueのテンプレートとなるyaml形式のファイルを作成した

## 課題
- 特になし

## イメージ画像
- 特になし

## 関連Issue / PR
- #43
- #59 